### PR TITLE
feature/cache-database: Database Failover Cache & Error Handling

### DIFF
--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,24 +1,28 @@
 // src/app/api/advocates/route.ts
-
 import db from "@/db";
 import { advocates } from "@/db/schema";
 import { NextRequest } from "next/server";
+import { Advocate, AdvocatesCache } from "@/types/advocate";
 
-type Advocate = {
-  specialties: string[];
-  city: string;
-};
+let advocatesCache: AdvocatesCache | null = null;
 
 export async function GET(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams;
     const page = parseInt(searchParams.get("page") || "1");
     const pageSize = parseInt(searchParams.get("pageSize") || "10");
-    const data = (await db.select().from(advocates)) as Advocate[];
     const specialty = searchParams.get("specialty");
     const city = searchParams.get("city");
 
-    // using the database
+    // Try to get data from database
+    const data = (await db.select().from(advocates)) as Advocate[];
+
+    // if successful - update cache
+    const currentTime = Date.now();
+    advocatesCache = {
+      data,
+      timestamp: currentTime,
+    };
 
     let filteredData = data;
 
@@ -38,19 +42,84 @@ export async function GET(request: NextRequest) {
       page * pageSize
     );
 
+    const pagination = {
+      total,
+      page,
+      pageSize,
+      totalPages: Math.ceil(total / pageSize),
+    };
+
+    // update cache with pagination info
+    advocatesCache.pagination = pagination;
+
     return Response.json({
       data: paginatedData,
-      pagination: {
-        total,
-        page,
-        pageSize,
-        totalPages: Math.ceil(total / pageSize),
-      },
+      pagination,
+      status: "live",
     });
   } catch (error) {
     console.error("Error fetching advocates:", error);
+
+    // if cache exists - use it
+    if (advocatesCache && advocatesCache.data.length > 0) {
+      const { data, timestamp, pagination } = advocatesCache;
+      const searchParams = request.nextUrl.searchParams;
+      const specialty = searchParams.get("specialty");
+      const city = searchParams.get("city");
+
+      //apply same filters to cached data
+      let filteredData = data;
+      if (specialty) {
+        filteredData = filteredData.filter((advocate) =>
+          advocate.specialties.includes(specialty)
+        );
+      }
+      if (city) {
+        filteredData = filteredData.filter(
+          (advocate) => advocate.city === city
+        );
+      }
+
+      const page = parseInt(searchParams.get("page") || "1");
+      const pageSize = parseInt(searchParams.get("pageSize") || "10");
+      const total = filteredData.length;
+      const paginatedData = filteredData.slice(
+        (page - 1) * pageSize,
+        page * pageSize
+      );
+
+      // calculate time since last update
+      const now = Date.now();
+      const timeSinceUpdate = now - timestamp;
+      const minutes = Math.floor(timeSinceUpdate / 60000);
+      const hours = Math.floor(minutes / 60);
+      const days = Math.floor(hours / 24);
+
+      let lastUpdated: string;
+      if (days > 0) {
+        lastUpdated = `${days} ${days === 1 ? "day" : "days"}`;
+      } else if (hours > 0) {
+        lastUpdated = `${hours} ${hours === 1 ? "hour" : "hours"}`;
+      } else {
+        lastUpdated = `${minutes} ${minutes === 1 ? "minute" : "minutes"}`;
+      }
+
+      return Response.json({
+        data: paginatedData,
+        pagination: {
+          total,
+          page,
+          pageSize,
+          totalPages: Math.ceil(total / pageSize),
+        },
+        status: "cached",
+        lastUpdated,
+      });
+    }
+
+    // no cache available
     return Response.json(
-      { error: "Failed to fetch advocates" },
+      { error: "Failed to fetch advocates", status: "error" },
       { status: 500 }
     );
   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,8 +9,8 @@ import {
   XCircleIcon,
   FilterIcon,
   ChevronDownIcon,
+  AlertCircleIcon,
 } from "lucide-react";
-import Image from "next/image";
 import { debounce } from "lodash";
 
 // Components
@@ -75,6 +75,11 @@ const styles = {
   errorMessage: "text-red-600 mb-6",
   tryAgainButton:
     "px-5 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 transition-colors",
+  alertBanner:
+    "mb-6 px-4 py-3 bg-amber-50 border border-amber-200 rounded-lg flex items-center gap-3",
+  alertIcon: "flex-shrink-0 text-amber-500",
+  alertMessage: "text-amber-800 text-sm",
+  alertTime: "font-semibold",
 };
 
 export default function Home() {
@@ -91,6 +96,8 @@ export default function Home() {
   const [totalItems, setTotalItems] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
   const [allAdvocates, setAllAdvocates] = useState<Advocate[]>([]);
+  const [dataStatus, setDataStatus] = useState<"live" | "cached" | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<string | null>(null);
 
   useEffect(() => {
     const fetchAdvocates = async () => {
@@ -102,6 +109,15 @@ export default function Home() {
         }
         const allData = await allResponse.json();
         setAllAdvocates(allData.data);
+
+        // Check if using cached data
+        if (allData.status === "cached") {
+          setDataStatus("cached");
+          setLastUpdated(allData.lastUpdated);
+        } else {
+          setDataStatus("live");
+          setLastUpdated(null);
+        }
 
         //  fetch paginated data
         const response = await fetch(
@@ -327,6 +343,17 @@ export default function Home() {
           preferences.
         </p>
       </header>
+
+      {/* Cached data alert banner */}
+      {dataStatus === "cached" && lastUpdated && (
+        <div className={styles.alertBanner} role="alert">
+          <AlertCircleIcon size={20} className={styles.alertIcon} />
+          <p className={styles.alertMessage}>
+            Database connection failed. Showing cached data from{" "}
+            <span className={styles.alertTime}>{lastUpdated}</span> ago.
+          </p>
+        </div>
+      )}
 
       <div className={styles.gridLayout}>
         {/* Filters sidebar - desktop */}

--- a/src/types/advocate.ts
+++ b/src/types/advocate.ts
@@ -11,3 +11,15 @@ export interface Advocate {
   phoneNumber: number;
   createdAt?: string;
 }
+
+// Cache storage
+export interface AdvocatesCache {
+  data: Advocate[];
+  timestamp: number;
+  pagination?: {
+    total: number;
+    page: number;
+    pageSize: number;
+    totalPages: number;
+  };
+}


### PR DESCRIPTION
Implemented a fallback cache system so users can still browse advocates even when the database is down. Added a simple notification banner that lets users know they're seeing cached data and when it was last updated.

To test, start the app normally with `docker compose up -d` in one terminal and `npm run dev` in another. Load the app, then `docker compose down`, and refresh the app. You should see the message that informs the user about the failed DB connection and that it's showing cached data.

![image](https://github.com/user-attachments/assets/0a3349cb-70d3-400b-8f6e-3ca1dc3c67cc)
