### PR TITLE
bugfix/fullname_search_fix: Bugfix to fix full name search query

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -151,15 +151,21 @@ export default function Home() {
   const filterAdvocates = useCallback(
     debounce(() => {
       const filtered = allAdvocates.filter((advocate) => {
+        // create fullname for combined search
+        const fullName =
+          `${advocate.firstName} ${advocate.lastName}`.toLowerCase();
+        const searchTermLower = searchTerm.toLowerCase();
+
         // search term filtering
         const matchesSearch =
           searchTerm === "" ||
-          advocate.firstName.toLowerCase().includes(searchTerm.toLowerCase()) ||
-          advocate.lastName.toLowerCase().includes(searchTerm.toLowerCase()) ||
-          advocate.city.toLowerCase().includes(searchTerm.toLowerCase()) ||
-          advocate.degree.toLowerCase().includes(searchTerm.toLowerCase()) ||
+          fullName.includes(searchTermLower) ||
+          advocate.firstName.toLowerCase().includes(searchTermLower) ||
+          advocate.lastName.toLowerCase().includes(searchTermLower) ||
+          advocate.city.toLowerCase().includes(searchTermLower) ||
+          advocate.degree.toLowerCase().includes(searchTermLower) ||
           advocate.specialties.some((s) =>
-            s.toLowerCase().includes(searchTerm.toLowerCase())
+            s.toLowerCase().includes(searchTermLower)
           );
 
         //specialty filtering


### PR DESCRIPTION
Previously the search functionality wasn't working properly when the user would attempt to search by a first name AND last name. If the user wanted to find "jane smith", searching for "jane" or "ja" would yield results, but searching for "jane smith" or "jane smi" would return with 0 results. This PR fixes that and accounts for full name searches.

Before:
![image](https://github.com/user-attachments/assets/4f084dd4-547b-4f94-a24e-0d65b96af7ec)

After:
![image](https://github.com/user-attachments/assets/adc5ed54-e02b-4b60-b84f-ca71fa3f28a0)

